### PR TITLE
fix dremio include-ssh-tunnel call

### DIFF
--- a/src/metabase/driver/dremio.clj
+++ b/src/metabase/driver/dremio.clj
@@ -106,7 +106,7 @@
 ;    {"preferredTestQuery" "SELECT 1"}))
 
 (defmethod driver/can-connect? :dremio [driver details]
-  (let [connection (sql-jdbc.conn/connection-details->spec driver (ssh/include-ssh-tunnel details))]
+  (let [connection (sql-jdbc.conn/connection-details->spec driver (ssh/include-ssh-tunnel! details))]
     (= 1 (first (vals (first (jdbc/query connection ["SELECT count(1)"])))))))
 
 (defmethod sql-jdbc.sync/database-type->base-type :dremio


### PR DESCRIPTION
This var has been renamed to include-ssh-tunnel! in the original repo,
needs to be renamed here too.

See: https://github.com/metabase/metabase/commit/b4d8e35ad3